### PR TITLE
[psud] Add PSU Hardware Revision to Redis STATE_DB

### DIFF
--- a/sonic-psud/scripts/psud
+++ b/sonic-psud/scripts/psud
@@ -48,6 +48,7 @@ PSU_INFO_KEY_TEMPLATE = 'PSU {}'
 PSU_INFO_PRESENCE_FIELD = 'presence'
 PSU_INFO_MODEL_FIELD = 'model'
 PSU_INFO_SERIAL_FIELD = 'serial'
+PSU_INFO_REV_FIELD = 'revision'
 PSU_INFO_STATUS_FIELD = 'status'
 PSU_INFO_TEMP_FIELD = 'temp'
 PSU_INFO_TEMP_TH_FIELD = 'temp_threshold'
@@ -510,6 +511,7 @@ class DaemonPsud(daemon_base.DaemonBase):
         fvs = swsscommon.FieldValuePairs(
             [(PSU_INFO_MODEL_FIELD, str(try_get(psu.get_model, NOT_AVAILABLE))),
              (PSU_INFO_SERIAL_FIELD, str(try_get(psu.get_serial, NOT_AVAILABLE))),
+             (PSU_INFO_REV_FIELD, str(try_get(psu.get_revision, NOT_AVAILABLE))),
              (PSU_INFO_TEMP_FIELD, str(temperature)),
              (PSU_INFO_TEMP_TH_FIELD, str(temperature_threshold)),
              (PSU_INFO_VOLTAGE_FIELD, str(voltage)),

--- a/sonic-psud/tests/mock_platform.py
+++ b/sonic-psud/tests/mock_platform.py
@@ -273,6 +273,7 @@ class MockPsu(psu_base.PsuBase):
                  presence=True,
                  model='Module Model',
                  serial='Module Serial',
+                 revision='Module Revision',
                  status=True,
                  voltage=12.0,
                  current=8.0,
@@ -287,6 +288,7 @@ class MockPsu(psu_base.PsuBase):
         self._presence = presence
         self._model = model
         self._serial = serial
+        self._revision = revision
         self._status = status
         self._position_in_parent = position_in_parent
         self._replaceable = replaceable
@@ -364,6 +366,9 @@ class MockPsu(psu_base.PsuBase):
 
     def get_serial(self):
         return self._serial
+
+    def get_revision(self):
+        return self._revision
 
     def get_status(self):
         return self._status

--- a/sonic-psud/tests/test_DaemonPsud.py
+++ b/sonic-psud/tests/test_DaemonPsud.py
@@ -148,13 +148,14 @@ class TestDaemonPsud(object):
         psud._wrapper_get_psu_presence.return_value = True
         psud._wrapper_get_psu_status.return_value = True
 
-        psu1 = MockPsu('PSU 1', 0, True, 'Fake Model', '12345678')
+        psu1 = MockPsu('PSU 1', 0, True, 'Fake Model', '12345678', '1234')
         psud.platform_chassis = MockChassis()
         psud.platform_chassis._psu_list.append(psu1)
 
         expected_fvp = psud.swsscommon.FieldValuePairs(
             [(psud.PSU_INFO_MODEL_FIELD, 'Fake Model'),
              (psud.PSU_INFO_SERIAL_FIELD, '12345678'),
+             (psud.PSU_INFO_REV_FIELD, '1234'),
              (psud.PSU_INFO_TEMP_FIELD, '30.0'),
              (psud.PSU_INFO_TEMP_TH_FIELD, '50.0'),
              (psud.PSU_INFO_VOLTAGE_FIELD, '12.0'),


### PR DESCRIPTION
#### Description
Added "hardware revision" field to list of platform fields to sync to STATE_DB for the PSU. Also updated relevant unit tests. 

#### Motivation and Context
Now that hardware revision exists as a platform 2.0 field for all devices, it is appropriate to synchronize this field to STATE_DB for PSUs as is done with all other fields. This will allow this field to be exposed to CLI tools through psushow in the future which reads state from STATE_DB. 

#### How Has This Been Tested?

This has been tested on all mellanox platforms aside from MSN2010. Tested by deploying change and verifying that "revision" was present in STATE_DB for all platforms that support it. 
