### PR TITLE
Implement --init-only mode for non-modular platforms

### DIFF
--- a/sonic-chassisd/scripts/chassisd
+++ b/sonic-chassisd/scripts/chassisd
@@ -37,9 +37,6 @@ CHASSIS_CFG_TABLE = 'CHASSIS_MODULE'
 CHASSIS_INFO_TABLE = 'CHASSIS_TABLE'
 CHASSIS_INFO_KEY_TEMPLATE = 'CHASSIS {}'
 CHASSIS_INFO_CARD_NUM_FIELD = 'module_num'
-CHASSIS_INFO_SERIAL_FIELD = 'serial'
-CHASSIS_INFO_MODEL_FIELD = 'model'
-CHASSIS_INFO_REV_FIELD = 'revision'
 
 CHASSIS_MODULE_INFO_TABLE = 'CHASSIS_MODULE_TABLE'
 CHASSIS_MODULE_INFO_KEY_TEMPLATE = 'CHASSIS_MODULE {}'
@@ -156,6 +153,11 @@ class ModuleUpdater(logger.Logger):
 
         self.chassis = chassis
         self.num_modules = chassis.get_num_modules()
+        # Connect to STATE_DB and create chassis info tables
+        state_db = daemon_base.db_connect("STATE_DB")
+        self.chassis_table = swsscommon.Table(state_db, CHASSIS_INFO_TABLE)
+        self.module_table = swsscommon.Table(state_db, CHASSIS_MODULE_INFO_TABLE)
+        self.midplane_table = swsscommon.Table(state_db, CHASSIS_MIDPLANE_INFO_TABLE)
         self.info_dict_keys = [CHASSIS_MODULE_INFO_NAME_FIELD,
                                CHASSIS_MODULE_INFO_DESC_FIELD,
                                CHASSIS_MODULE_INFO_SLOT_FIELD,
@@ -165,7 +167,22 @@ class ModuleUpdater(logger.Logger):
         if not self.midplane_initialized:
             self.log_error("Chassisd midplane intialization failed")
 
-    def modules_num_update(self, chassis_table):
+    def deinit(self):
+        """
+        Destructor of ModuleUpdater
+        :return:
+        """
+        # Delete all the information from DB and then exit
+        for module_index in range(0, self.num_modules):
+            name = try_get(self.chassis.get_module(module_index).get_name)
+            self.module_table._del(name)
+            if self.midplane_table.get(name) is not None:
+                self.midplane_table._del(name)
+
+        if self.chassis_table is not None:
+            self.chassis_table._del(CHASSIS_INFO_KEY_TEMPLATE.format(1))
+
+    def modules_num_update(self):
         # Check if module list is populated
         num_modules = self.chassis.get_num_modules()
         if num_modules == 0:
@@ -174,9 +191,9 @@ class ModuleUpdater(logger.Logger):
 
         # Post number-of-modules info to STATE_DB
         fvs = swsscommon.FieldValuePairs([(CHASSIS_INFO_CARD_NUM_FIELD, str(num_modules))])
-        chassis_table.set(CHASSIS_INFO_KEY_TEMPLATE.format(1), fvs)
+        self.chassis_table.set(CHASSIS_INFO_KEY_TEMPLATE.format(1), fvs)
 
-    def module_db_update(self, module_table):
+    def module_db_update(self):
         for module_index in range(0, self.num_modules):
             module_info_dict = self._get_module_info(module_index)
             if module_info_dict is not None:
@@ -195,7 +212,7 @@ class ModuleUpdater(logger.Logger):
                                                   (CHASSIS_MODULE_INFO_SLOT_FIELD,
                                                    module_info_dict[CHASSIS_MODULE_INFO_SLOT_FIELD]),
                                                   (CHASSIS_MODULE_INFO_OPERSTATUS_FIELD, module_info_dict[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD])])
-                module_table.set(key, fvs)
+                self.module_table.set(key, fvs)
 
     def _get_module_info(self, module_index):
         """
@@ -222,7 +239,7 @@ class ModuleUpdater(logger.Logger):
         else:
             return False
 
-    def check_midplane_reachability(self, midplane_table):
+    def check_midplane_reachability(self):
         if not self.midplane_initialized:
             return
 
@@ -249,7 +266,7 @@ class ModuleUpdater(logger.Logger):
             # Update db with midplane information
             fvs = swsscommon.FieldValuePairs([(CHASSIS_MIDPLANE_INFO_IP_FIELD, midplane_ip),
                                               (CHASSIS_MIDPLANE_INFO_ACCESS_FIELD, str(midplane_access))])
-            midplane_table.set(module_key, fvs)
+            self.midplane_table.set(module_key, fvs)
 
 #
 # Config Manager task ========================================================
@@ -321,7 +338,7 @@ class ChassisdDaemon(daemon_base.DaemonBase):
             self.log_warning("Caught unhandled signal '" + sig + "'")
 
     # Run daemon
-    def run(self, init_only=False):
+    def run(self):
         global platform_chassis
 
         self.log_info("Starting up...")
@@ -334,24 +351,9 @@ class ChassisdDaemon(daemon_base.DaemonBase):
             self.log_error("Failed to load chassis due to {}".format(repr(e)))
             sys.exit(CHASSIS_LOAD_ERROR)
 
-        # Init state db connection
-        state_db = daemon_base.db_connect("STATE_DB")
-        chassis_table = swsscommon.Table(state_db, CHASSIS_INFO_TABLE)
-        module_table = swsscommon.Table(state_db, CHASSIS_MODULE_INFO_TABLE)
-        midplane_table = swsscommon.Table(state_db, CHASSIS_MIDPLANE_INFO_TABLE)
-
-        # Populate DB with chassis hardware info 
-        fvs = swsscommon.FieldValuePairs([
-                                            (CHASSIS_INFO_SERIAL_FIELD, platform_chassis.get_serial()),
-                                            (CHASSIS_INFO_MODEL_FIELD, platform_chassis.get_model()),
-                                            (CHASSIS_INFO_REV_FIELD, platform_chassis.get_revision())
-                                        ])
-        chassis_table.set(CHASSIS_INFO_KEY_TEMPLATE.format(1), fvs)
-        if init_only: return
-
         # Check if module list is populated
         self.module_updater = ModuleUpdater(SYSLOG_IDENTIFIER, platform_chassis)
-        self.module_updater.modules_num_update(chassis_table)
+        self.module_updater.modules_num_update()
 
         # Check for valid slot numbers
         self.module_updater.my_slot = try_get(platform_chassis.get_my_slot,
@@ -372,8 +374,8 @@ class ChassisdDaemon(daemon_base.DaemonBase):
         self.log_info("Start daemon main loop")
 
         while not self.stop.wait(CHASSIS_INFO_UPDATE_PERIOD_SECS):
-            self.module_updater.module_db_update(module_table)
-            self.module_updater.check_midplane_reachability(midplane_table)
+            self.module_updater.module_db_update()
+            self.module_updater.check_midplane_reachability()
 
         self.log_info("Stop daemon main loop")
 
@@ -381,14 +383,7 @@ class ChassisdDaemon(daemon_base.DaemonBase):
             config_manager.task_stop()
 
         # Delete all the information from DB and then exit
-        for module_index in range(0, platform_chassis.get_num_modules()):
-            name = try_get(platform_chassis.get_module(module_index).get_name)
-            module_table._del(name)
-            if midplane_table.get(name) is not None:
-                midplane_table._del(name)
-
-        if chassis_table is not None:
-            chassis_table._del(CHASSIS_INFO_KEY_TEMPLATE.format(1))
+        self.module_updater.deinit()
 
         self.log_info("Shutting down...")
 
@@ -399,7 +394,7 @@ class ChassisdDaemon(daemon_base.DaemonBase):
 
 def main():
     chassisd = ChassisdDaemon(SYSLOG_IDENTIFIER)
-    chassisd.run(init_only=("--init-only" in sys.argv))
+    chassisd.run()
 
 
 if __name__ == '__main__':

--- a/sonic-chassisd/scripts/chassisd
+++ b/sonic-chassisd/scripts/chassisd
@@ -37,6 +37,9 @@ CHASSIS_CFG_TABLE = 'CHASSIS_MODULE'
 CHASSIS_INFO_TABLE = 'CHASSIS_TABLE'
 CHASSIS_INFO_KEY_TEMPLATE = 'CHASSIS {}'
 CHASSIS_INFO_CARD_NUM_FIELD = 'module_num'
+CHASSIS_INFO_SERIAL_FIELD = 'serial'
+CHASSIS_INFO_MODEL_FIELD = 'model'
+CHASSIS_INFO_REV_FIELD = 'revision'
 
 CHASSIS_MODULE_INFO_TABLE = 'CHASSIS_MODULE_TABLE'
 CHASSIS_MODULE_INFO_KEY_TEMPLATE = 'CHASSIS_MODULE {}'
@@ -153,11 +156,6 @@ class ModuleUpdater(logger.Logger):
 
         self.chassis = chassis
         self.num_modules = chassis.get_num_modules()
-        # Connect to STATE_DB and create chassis info tables
-        state_db = daemon_base.db_connect("STATE_DB")
-        self.chassis_table = swsscommon.Table(state_db, CHASSIS_INFO_TABLE)
-        self.module_table = swsscommon.Table(state_db, CHASSIS_MODULE_INFO_TABLE)
-        self.midplane_table = swsscommon.Table(state_db, CHASSIS_MIDPLANE_INFO_TABLE)
         self.info_dict_keys = [CHASSIS_MODULE_INFO_NAME_FIELD,
                                CHASSIS_MODULE_INFO_DESC_FIELD,
                                CHASSIS_MODULE_INFO_SLOT_FIELD,
@@ -167,22 +165,7 @@ class ModuleUpdater(logger.Logger):
         if not self.midplane_initialized:
             self.log_error("Chassisd midplane intialization failed")
 
-    def deinit(self):
-        """
-        Destructor of ModuleUpdater
-        :return:
-        """
-        # Delete all the information from DB and then exit
-        for module_index in range(0, self.num_modules):
-            name = try_get(self.chassis.get_module(module_index).get_name)
-            self.module_table._del(name)
-            if self.midplane_table.get(name) is not None:
-                self.midplane_table._del(name)
-
-        if self.chassis_table is not None:
-            self.chassis_table._del(CHASSIS_INFO_KEY_TEMPLATE.format(1))
-
-    def modules_num_update(self):
+    def modules_num_update(self, chassis_table):
         # Check if module list is populated
         num_modules = self.chassis.get_num_modules()
         if num_modules == 0:
@@ -191,9 +174,9 @@ class ModuleUpdater(logger.Logger):
 
         # Post number-of-modules info to STATE_DB
         fvs = swsscommon.FieldValuePairs([(CHASSIS_INFO_CARD_NUM_FIELD, str(num_modules))])
-        self.chassis_table.set(CHASSIS_INFO_KEY_TEMPLATE.format(1), fvs)
+        chassis_table.set(CHASSIS_INFO_KEY_TEMPLATE.format(1), fvs)
 
-    def module_db_update(self):
+    def module_db_update(self, module_table):
         for module_index in range(0, self.num_modules):
             module_info_dict = self._get_module_info(module_index)
             if module_info_dict is not None:
@@ -212,7 +195,7 @@ class ModuleUpdater(logger.Logger):
                                                   (CHASSIS_MODULE_INFO_SLOT_FIELD,
                                                    module_info_dict[CHASSIS_MODULE_INFO_SLOT_FIELD]),
                                                   (CHASSIS_MODULE_INFO_OPERSTATUS_FIELD, module_info_dict[CHASSIS_MODULE_INFO_OPERSTATUS_FIELD])])
-                self.module_table.set(key, fvs)
+                module_table.set(key, fvs)
 
     def _get_module_info(self, module_index):
         """
@@ -239,7 +222,7 @@ class ModuleUpdater(logger.Logger):
         else:
             return False
 
-    def check_midplane_reachability(self):
+    def check_midplane_reachability(self, midplane_table):
         if not self.midplane_initialized:
             return
 
@@ -266,7 +249,7 @@ class ModuleUpdater(logger.Logger):
             # Update db with midplane information
             fvs = swsscommon.FieldValuePairs([(CHASSIS_MIDPLANE_INFO_IP_FIELD, midplane_ip),
                                               (CHASSIS_MIDPLANE_INFO_ACCESS_FIELD, str(midplane_access))])
-            self.midplane_table.set(module_key, fvs)
+            midplane_table.set(module_key, fvs)
 
 #
 # Config Manager task ========================================================
@@ -338,7 +321,7 @@ class ChassisdDaemon(daemon_base.DaemonBase):
             self.log_warning("Caught unhandled signal '" + sig + "'")
 
     # Run daemon
-    def run(self):
+    def run(self, init_only=False):
         global platform_chassis
 
         self.log_info("Starting up...")
@@ -351,9 +334,24 @@ class ChassisdDaemon(daemon_base.DaemonBase):
             self.log_error("Failed to load chassis due to {}".format(repr(e)))
             sys.exit(CHASSIS_LOAD_ERROR)
 
+        # Init state db connection
+        state_db = daemon_base.db_connect("STATE_DB")
+        chassis_table = swsscommon.Table(state_db, CHASSIS_INFO_TABLE)
+        module_table = swsscommon.Table(state_db, CHASSIS_MODULE_INFO_TABLE)
+        midplane_table = swsscommon.Table(state_db, CHASSIS_MIDPLANE_INFO_TABLE)
+
+        # Populate DB with chassis hardware info 
+        fvs = swsscommon.FieldValuePairs([
+                                            (CHASSIS_INFO_SERIAL_FIELD, platform_chassis.get_serial()),
+                                            (CHASSIS_INFO_MODEL_FIELD, platform_chassis.get_model()),
+                                            (CHASSIS_INFO_REV_FIELD, platform_chassis.get_revision())
+                                        ])
+        chassis_table.set(CHASSIS_INFO_KEY_TEMPLATE.format(1), fvs)
+        if init_only: return
+
         # Check if module list is populated
         self.module_updater = ModuleUpdater(SYSLOG_IDENTIFIER, platform_chassis)
-        self.module_updater.modules_num_update()
+        self.module_updater.modules_num_update(chassis_table)
 
         # Check for valid slot numbers
         self.module_updater.my_slot = try_get(platform_chassis.get_my_slot,
@@ -374,8 +372,8 @@ class ChassisdDaemon(daemon_base.DaemonBase):
         self.log_info("Start daemon main loop")
 
         while not self.stop.wait(CHASSIS_INFO_UPDATE_PERIOD_SECS):
-            self.module_updater.module_db_update()
-            self.module_updater.check_midplane_reachability()
+            self.module_updater.module_db_update(module_table)
+            self.module_updater.check_midplane_reachability(midplane_table)
 
         self.log_info("Stop daemon main loop")
 
@@ -383,7 +381,14 @@ class ChassisdDaemon(daemon_base.DaemonBase):
             config_manager.task_stop()
 
         # Delete all the information from DB and then exit
-        self.module_updater.deinit()
+        for module_index in range(0, platform_chassis.get_num_modules()):
+            name = try_get(platform_chassis.get_module(module_index).get_name)
+            module_table._del(name)
+            if midplane_table.get(name) is not None:
+                midplane_table._del(name)
+
+        if chassis_table is not None:
+            chassis_table._del(CHASSIS_INFO_KEY_TEMPLATE.format(1))
 
         self.log_info("Shutting down...")
 
@@ -394,7 +399,7 @@ class ChassisdDaemon(daemon_base.DaemonBase):
 
 def main():
     chassisd = ChassisdDaemon(SYSLOG_IDENTIFIER)
-    chassisd.run()
+    chassisd.run(init_only=("--init-only" in sys.argv))
 
 
 if __name__ == '__main__':

--- a/sonic-chassisd/scripts/chassisshow
+++ b/sonic-chassisd/scripts/chassisshow
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+
+"""
+    chassisshow
+    Chassis information update tool for SONiC
+    This tool runs one time at the launch of the platform monitor in order to populate STATE_DB with chassis information such as model, serial number, and revision.
+"""
+
+try:
+    import sys
+
+    from sonic_py_common import daemon_base, logger
+
+except ImportError as e:
+    raise ImportError(str(e) + " - required module not found")
+
+#
+# Constants
+#
+
+SYSLOG_IDENTIFIER = "chassisshow"
+
+CHASSIS_INFO_TABLE = 'CHASSIS_TABLE'
+CHASSIS_INFO_KEY_TEMPLATE = 'CHASSIS {}'
+CHASSIS_INFO_CARD_NUM_FIELD = 'module_num'
+CHASSIS_INFO_SERIAL_FIELD = 'serial'
+CHASSIS_INFO_MODEL_FIELD = 'model'
+CHASSIS_INFO_REV_FIELD = 'revision'
+
+CHASSIS_LOAD_ERROR = 1
+
+#
+# Functions
+# 
+
+def provision_db():
+
+    log = logger.Logger(SYSLOG_IDENTIFIER)
+    log.log_info("Provisioning Database with Chassis Info...")
+
+    # Load platform api class
+    try:
+        import sonic_platform.platform
+        platform_chassis = sonic_platform.platform.Platform().get_chassis()
+    except Exception as e:
+        log.log_error("Failed to load chassis due to {}".format(repr(e)))
+        sys.exit(CHASSIS_LOAD_ERROR)
+
+    # Init state db connection
+    state_db = daemon_base.db_connect("STATE_DB")
+    chassis_table = swsscommon.Table(state_db, CHASSIS_INFO_TABLE)
+    module_table = swsscommon.Table(state_db, CHASSIS_MODULE_INFO_TABLE)
+    midplane_table = swsscommon.Table(state_db, CHASSIS_MIDPLANE_INFO_TABLE)
+
+    # Populate DB with chassis hardware info 
+    fvs = swsscommon.FieldValuePairs([
+                                        (CHASSIS_INFO_SERIAL_FIELD, platform_chassis.get_serial()),
+                                        (CHASSIS_INFO_MODEL_FIELD, platform_chassis.get_model()),
+                                        (CHASSIS_INFO_REV_FIELD, platform_chassis.get_revision())
+                                    ])
+    chassis_table.set(CHASSIS_INFO_KEY_TEMPLATE.format(1), fvs)
+    log.log_info("STATE_DB provisioned with chassis info.")
+
+
+#
+# Main
+#
+
+def main():
+    provision_db()
+
+if __name__ == '__main__':
+    main()

--- a/sonic-chassisd/setup.py
+++ b/sonic-chassisd/setup.py
@@ -15,6 +15,7 @@ setup(
     ],
     scripts=[
         'scripts/chassisd',
+        'scripts/chassisshow'
     ],
     setup_requires=[
         'pytest-runner',


### PR DESCRIPTION
Proposal for chassisd revision to allow synchronizing basic platform information to STATE_DB on all platforms (not just modular ones)

Includes change to chassisd to accept the `--init-only` flag and slight refactoring to allow easier resource sharing of state_db objects. 