### PR TITLE
[xcvrd] Force cleanup of chassis object to properly close sx API connection

### DIFF
--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -1336,6 +1336,7 @@ class DaemonXcvrd(daemon_base.DaemonBase):
 
     # Deinitialize daemon
     def deinit(self):
+        global platform_chassis
         self.log_info("Start daemon deinit...")
 
         # Delete all the information from DB and then exit
@@ -1352,6 +1353,8 @@ class DaemonXcvrd(daemon_base.DaemonBase):
 
         if self.y_cable_presence[0] is True:
             y_cable_helper.delete_ports_status_for_y_cable()
+
+        del platform_chassis
 
     # Run daemon
 


### PR DESCRIPTION
#### Description
I added a `del` directive for the global `platform_chassis` object in `xcvrd` on deinit to ensure that the pointer is properly cleaned up such that the `__del__()` method is successfully called on the chassis object which closes its connection to SAI. 

#### Motivation and Context
On Mellanox platforms on 202012 we are seeing that in some cases xcvrd is maintaining the socket to the API past its deconstruction causing an error from SAI. This was traced by reproducing the issue and identifying that the pmon container was causing this issue where xcvrd is the only daemon within pmon that opens a SDK socket on Mellanox. 

Error in log...
```
syncd#SDK: [SX_API_INTERNAL.ERR] Failed command read at communication channel: Connection reset by peer
```

#### How Has This Been Tested?
Change was uploaded to xcvrd on running pmon container on a switch running the latest 202012 build. xcvrd was then restarted with supervisord and we verified that we could no longer reproduce the bug. 
